### PR TITLE
add new commands to support plain scan

### DIFF
--- a/src/jtag/core.c
+++ b/src/jtag/core.c
@@ -445,14 +445,14 @@ void jtag_add_dr_scan_check(struct jtag_tap *active,
 void jtag_add_dr_scan_plainscan(struct jtag_tap *active,
 	int in_num_fields,
 	const struct scan_field *in_fields,
-	tap_state_t state, bool is_plain)
+	tap_state_t state, bool is_plain, bool is_drscan)
 {
 	assert(state != TAP_RESET);
 
 	jtag_prelude(state);
 
 	int retval;
-	retval = interface_jtag_add_dr_scan(active, in_num_fields, in_fields, state, is_plain);
+	retval = interface_jtag_add_dr_scan(active, in_num_fields, in_fields, state, is_plain, is_drscan);
 	jtag_set_error(retval);
 }
 
@@ -461,7 +461,7 @@ void jtag_add_dr_scan(struct jtag_tap *active,
 	const struct scan_field *in_fields,
 	tap_state_t state)
 {
-	jtag_add_dr_scan_plainscan(active, in_num_fields, in_fields, state, false);
+	jtag_add_dr_scan_plainscan(active, in_num_fields, in_fields, state, false, true);
 }
 
 void jtag_add_plain_dr_scan(int num_bits, const uint8_t *out_bits, uint8_t *in_bits,

--- a/src/jtag/core.c
+++ b/src/jtag/core.c
@@ -100,6 +100,7 @@ tap_state_t cmd_queue_cur_state = TAP_RESET;
 
 static bool jtag_verify_capture_ir = true;
 static int jtag_verify = 1;
+static int jtag_examine = 1;
 
 /* how long the OpenOCD should wait before attempting JTAG communication after reset lines
  *deasserted (in ms) */
@@ -1539,24 +1540,26 @@ int jtag_init_inner(struct command_context *cmd_ctx)
 	 * prevent communication ... hardware issues like TDO stuck, or
 	 * configuring the wrong number of (enabled) TAPs.
 	 */
-	retval = jtag_examine_chain();
-	switch (retval) {
-		case ERROR_OK:
-			/* complete success */
-			break;
-		default:
-			/* For backward compatibility reasons, try coping with
-			 * configuration errors involving only ID mismatches.
-			 * We might be able to talk to the devices.
-			 *
-			 * Also the device might be powered down during startup.
-			 *
-			 * After OpenOCD starts, we can try to power on the device
-			 * and run a reset.
-			 */
-			LOG_ERROR("Trying to use configured scan chain anyway...");
-			issue_setup = false;
-			break;
+	if (jtag_examine) {
+		retval = jtag_examine_chain();
+		switch (retval) {
+			case ERROR_OK:
+				/* complete success */
+				break;
+			default:
+				/* For backward compatibility reasons, try coping with
+				 * configuration errors involving only ID mismatches.
+				 * We might be able to talk to the devices.
+				 *
+				 * Also the device might be powered down during startup.
+				 *
+				 * After OpenOCD starts, we can try to power on the device
+				 * and run a reset.
+				 */
+				LOG_ERROR("Trying to use configured scan chain anyway...");
+				issue_setup = false;
+				break;
+		}
 	}
 
 	/* Now look at IR values.  Problems here will prevent real
@@ -1688,6 +1691,16 @@ int jtag_init(struct command_context *cmd_ctx)
 		return ERROR_FAIL;
 
 	return ERROR_OK;
+}
+
+void jtag_set_examine_chain(bool enable)
+{
+	jtag_examine = enable;
+}
+
+bool jtag_will_examine_chain(void)
+{
+	return jtag_examine;
 }
 
 void jtag_set_verify(bool enable)

--- a/src/jtag/drivers/driver.c
+++ b/src/jtag/drivers/driver.c
@@ -116,7 +116,7 @@ int interface_jtag_add_ir_scan(struct jtag_tap *active,
  *
  */
 int interface_jtag_add_dr_scan(struct jtag_tap *active, int in_num_fields,
-		const struct scan_field *in_fields, tap_state_t state, bool is_plain)
+		const struct scan_field *in_fields, tap_state_t state, bool is_plain, bool is_drscan)
 {
 	/* count devices in bypass */
 
@@ -138,7 +138,7 @@ int interface_jtag_add_dr_scan(struct jtag_tap *active, int in_num_fields,
 	cmd->type = JTAG_SCAN;
 	cmd->cmd.scan = scan;
 
-	scan->ir_scan = false;
+	scan->ir_scan = !is_drscan;
 	scan->num_fields = in_num_fields + bypass_devices;
 	scan->fields = out_fields;
 	scan->end_state = state;

--- a/src/jtag/drivers/driver.c
+++ b/src/jtag/drivers/driver.c
@@ -147,32 +147,47 @@ int interface_jtag_add_dr_scan(struct jtag_tap *active, int in_num_fields,
 
 	/* loop over all enabled TAPs */
 
-	for (struct jtag_tap *tap = jtag_tap_next_enabled(NULL); tap; tap = jtag_tap_next_enabled(tap)) {
-		/* if TAP is not bypassed insert matching input fields */
-
-		if (!tap->bypass) {
-			assert(active == tap);
+	if (is_plain) {
 #ifndef NDEBUG
-			/* remember initial position for assert() */
-			struct scan_field *start_field = field;
+		/* remember initial position for assert() */
+		struct scan_field *start_field = field;
 #endif /* NDEBUG */
 
-			for (int j = 0; j < in_num_fields; j++) {
-				jtag_scan_field_clone(field, in_fields + j);
+		for (int j = 0; j < in_num_fields; j++) {
+			jtag_scan_field_clone(field, in_fields + j);
+
+			field++;
+		}
+
+		assert(field > start_field);	/* must have at least one input field per not bypassed TAP */
+	} else {
+		for (struct jtag_tap *tap = jtag_tap_next_enabled(NULL); tap; tap = jtag_tap_next_enabled(tap)) {
+			/* if TAP is not bypassed insert matching input fields */
+
+			if (!tap->bypass) {
+				assert(active == tap);
+#ifndef NDEBUG
+				/* remember initial position for assert() */
+				struct scan_field *start_field = field;
+#endif /* NDEBUG */
+
+				for (int j = 0; j < in_num_fields; j++) {
+					jtag_scan_field_clone(field, in_fields + j);
+
+					field++;
+				}
+
+				assert(field > start_field);	/* must have at least one input field per not bypassed TAP */
+			}
+
+			/* if a TAP is bypassed, generated a dummy bit*/
+			else if (!is_plain) {
+				field->num_bits = 1;
+				field->out_value = NULL;
+				field->in_value = NULL;
 
 				field++;
 			}
-
-			assert(field > start_field);	/* must have at least one input field per not bypassed TAP */
-		}
-
-		/* if a TAP is bypassed, generated a dummy bit*/
-		else if (!is_plain) {
-			field->num_bits = 1;
-			field->out_value = NULL;
-			field->in_value = NULL;
-
-			field++;
 		}
 	}
 

--- a/src/jtag/jtag.h
+++ b/src/jtag/jtag.h
@@ -323,7 +323,7 @@ void jtag_add_plain_ir_scan(int num_bits, const uint8_t *out_bits, uint8_t *in_b
  * No dummy fields will be added or removed if is_plain is set to true
  */
 void jtag_add_dr_scan_plainscan(struct jtag_tap *tap, int num_fields,
-		const struct scan_field *fields, tap_state_t endstate, bool is_plain);
+		const struct scan_field *fields, tap_state_t endstate, bool is_plain, bool is_drscan);
 /**
  * Generate a DR SCAN using the fields passed to the function.
  * For connected TAPs, the function checks in_fields and uses fields

--- a/src/jtag/jtag.h
+++ b/src/jtag/jtag.h
@@ -253,6 +253,10 @@ int jtag_get_trst(void);
 /** @returns The current state of SRST. */
 int jtag_get_srst(void);
 
+/** @returns True if JTAG scan examination will be performed. */
+bool jtag_will_examine_chain(void);
+/** Enable or disable JTAG scan examination checking. */
+void jtag_set_examine_chain(bool enable);
 /** Enable or disable data scan verification checking. */
 void jtag_set_verify(bool enable);
 /** @returns True if data scan verification will be performed. */

--- a/src/jtag/minidriver.h
+++ b/src/jtag/minidriver.h
@@ -56,7 +56,7 @@ int interface_jtag_add_plain_ir_scan(
 
 int interface_jtag_add_dr_scan(struct jtag_tap *active,
 		int num_fields, const struct scan_field *fields,
-		tap_state_t endstate, bool is_plain);
+		tap_state_t endstate, bool is_plain, bool is_drscan);
 int interface_jtag_add_plain_dr_scan(
 		int num_bits, const uint8_t *out_bits, uint8_t *in_bits,
 		tap_state_t endstate);

--- a/src/jtag/tcl.c
+++ b/src/jtag/tcl.c
@@ -83,7 +83,7 @@ static bool scan_is_safe(tap_state_t state)
 	}
 }
 
-static int jim_command_scan(Jim_Interp *interp, int argc, Jim_Obj * const *args, bool is_plain)
+static int jim_command_scan(Jim_Interp *interp, int argc, Jim_Obj * const *args, bool is_plain, bool is_drscan)
 {
 	int retval;
 	struct scan_field *fields;
@@ -188,7 +188,7 @@ static int jim_command_scan(Jim_Interp *interp, int argc, Jim_Obj * const *args,
 		field_count++;
 	}
 
-	jtag_add_dr_scan_plainscan(tap, num_fields, fields, endstate, is_plain);
+	jtag_add_dr_scan_plainscan(tap, num_fields, fields, endstate, is_plain, is_drscan);
 
 	retval = jtag_execute_queue();
 	if (retval != ERROR_OK) {
@@ -225,12 +225,17 @@ static int jim_command_scan(Jim_Interp *interp, int argc, Jim_Obj * const *args,
 
 static int jim_command_drscan(Jim_Interp *interp, int argc, Jim_Obj * const *args)
 {
-	return jim_command_scan(interp, argc, args, false);
+	return jim_command_scan(interp, argc, args, false, true);
 }
 
 static int jim_command_drplainscan(Jim_Interp *interp, int argc, Jim_Obj * const *args)
 {
-	return jim_command_scan(interp, argc, args, true);
+	return jim_command_scan(interp, argc, args, true, true);
+}
+
+static int jim_command_irplainscan(Jim_Interp *interp, int argc, Jim_Obj * const *args)
+{
+	return jim_command_scan(interp, argc, args, true, false);
 }
 
 static int jim_command_pathmove(Jim_Interp *interp, int argc, Jim_Obj * const *args)
@@ -300,7 +305,7 @@ static const struct command_registration jtag_command_handlers_to_move[] = {
 		.name = "drplainscan",
 		.mode = COMMAND_EXEC,
 		.jim_handler = jim_command_drplainscan,
-		.help = "Execute plain Data Register (DR) scan for one TAP.  "
+		.help = "Execute plain Data Register (DR) scan.  "
 			"Other TAPs must be in BYPASS mode. Unlike drscan, dummy bits for bypassed Taps are not added.",
 		.usage = "tap_name [num_bits value]* ['-endstate' state_name]",
 	},
@@ -318,6 +323,14 @@ static const struct command_registration jtag_command_handlers_to_move[] = {
 		.usage = "start_state state1 [state2 [state3 ...]]",
 		.help = "Move JTAG state machine from current state "
 			"(start_state) to state1, then state2, state3, etc.",
+	},
+	{
+		.name = "irplainscan",
+		.mode = COMMAND_EXEC,
+		.jim_handler = jim_command_irplainscan,
+		.help = "Execute plain Instruction Register (IR) scan.  "
+			"Unlike the irscan command, this command supports multiple value just like drscan and drplainscan. It will return the data from TDO",
+		.usage = "tap_name [num_bits value]* ['-endstate' state_name]",
 	},
 	COMMAND_REGISTRATION_DONE
 };

--- a/src/jtag/tcl.c
+++ b/src/jtag/tcl.c
@@ -90,7 +90,7 @@ static int jim_command_scan(Jim_Interp *interp, int argc, Jim_Obj * const *args,
 	int num_fields;
 	int field_count = 0;
 	int i, e;
-	struct jtag_tap *tap;
+	struct jtag_tap *tap = NULL;
 	tap_state_t endstate;
 
 	/* args[1] = device
@@ -162,9 +162,11 @@ static int jim_command_scan(Jim_Interp *interp, int argc, Jim_Obj * const *args,
 
 	assert(e == JIM_OK);
 
-	tap = jtag_tap_by_jim_obj(interp, args[1]);
-	if (!tap)
-		return JIM_ERR;
+	if (!is_plain) {
+		tap = jtag_tap_by_jim_obj(interp, args[1]);
+		if (!tap)
+			return JIM_ERR;
+	}
 
 	num_fields = (argc-2)/2;
 	if (num_fields <= 0) {
@@ -1231,6 +1233,23 @@ COMMAND_HANDLER(handle_verify_jtag_command)
 	return ERROR_OK;
 }
 
+COMMAND_HANDLER(handle_examine_chain_command)
+{
+	if (CMD_ARGC > 1)
+		return ERROR_COMMAND_SYNTAX_ERROR;
+
+	if (CMD_ARGC == 1) {
+		bool enable;
+		COMMAND_PARSE_ENABLE(CMD_ARGV[0], enable);
+		jtag_set_examine_chain(enable);
+	}
+
+	const char *status = jtag_will_examine_chain() ? "enabled" : "disabled";
+	command_print(CMD, "examine jtag chain is %s", status);
+
+	return ERROR_OK;
+}
+
 COMMAND_HANDLER(handle_tms_sequence_command)
 {
 	if (CMD_ARGC > 1)
@@ -1372,6 +1391,14 @@ static const struct command_registration jtag_command_handlers[] = {
 		.mode = COMMAND_ANY,
 		.help = "Display or assign flag controlling whether to "
 			"verify values captured during IR and DR scans.",
+		.usage = "['enable'|'disable']",
+	},
+	{
+		.name = "examine_chain",
+		.handler = handle_examine_chain_command,
+		.mode = COMMAND_ANY,
+		.help = "Display or assign flag controlling whether to "
+			"examine JTAG chain during initialization",
 		.usage = "['enable'|'disable']",
 	},
 	{


### PR DESCRIPTION
1. support plain IR scan by adding "irplainscan" command
2. return capture_ir data from the plain scan command
3. support disabling JTAG chain examination 