### PR TITLE
Support identifying USB device by using bus number and device address

### DIFF
--- a/src/jtag/adapter.c
+++ b/src/jtag/adapter.c
@@ -42,6 +42,9 @@ static struct {
 	enum adapter_clk_mode clock_mode;
 	int speed_khz;
 	int rclk_fallback_speed_khz;
+	int bus_number;
+	int device_address;
+	bool bus_address_initialized;
 } adapter_config;
 
 bool is_adapter_initialized(void)
@@ -250,6 +253,27 @@ static void adapter_usb_set_location(const char *location)
 const char *adapter_usb_get_location(void)
 {
 	return adapter_config.usb_location;
+}
+
+int adapter_usb_get_bus_number(void)
+{
+	if (adapter_config.bus_address_initialized)
+		return adapter_config.bus_number;
+	else
+		return -1;
+}
+
+int adapter_usb_get_device_address(void)
+{
+	if (adapter_config.bus_address_initialized)
+		return adapter_config.device_address;
+	else
+		return -1;
+}
+
+bool is_adapter_bus_address_initialized(void)
+{
+	return adapter_config.bus_address_initialized;
 }
 
 bool adapter_usb_location_equal(uint8_t dev_bus, uint8_t *port_path, size_t path_len)
@@ -770,6 +794,47 @@ COMMAND_HANDLER(handle_usb_location_command)
 }
 #endif /* HAVE_LIBUSB_GET_PORT_NUMBERS */
 
+COMMAND_HANDLER(handle_usb_bus_device_address_command)
+{
+	if (CMD_ARGC != 1) {
+		LOG_ERROR("too many arguments for the bus_address command");
+		return ERROR_COMMAND_SYNTAX_ERROR;
+	}
+	unsigned int bus;
+	unsigned int device;
+	char *argstr;
+	char *loc = strdup(CMD_ARGV[0]);
+	if (!loc) {
+		LOG_ERROR("string duplication failed\n");
+		return ERROR_COMMAND_ARGUMENT_OVERFLOW;
+	}
+	char *p_loc = loc;
+
+	argstr = strtok_r(p_loc, "-", &p_loc);
+	if (!argstr) {
+		LOG_ERROR("no '-' in usb bus_address\n");
+		free(loc);
+		return ERROR_COMMAND_SYNTAX_ERROR;
+	}
+	COMMAND_PARSE_NUMBER(uint, argstr, bus);
+	argstr = strtok_r(p_loc, "-", &p_loc);
+	if (!argstr) {
+		LOG_ERROR("device address is not specified in bus_address\n");
+		free(loc);
+		return ERROR_COMMAND_SYNTAX_ERROR;
+	}
+	COMMAND_PARSE_NUMBER(uint, argstr, device);
+
+	adapter_config.bus_number = bus;
+	adapter_config.device_address = device;
+	adapter_config.bus_address_initialized = true;
+
+	command_print(CMD, "adapter bus number: %d, device address: %d",
+		adapter_usb_get_bus_number(), adapter_usb_get_device_address());
+	free(loc);
+	return ERROR_OK;
+}
+
 static const struct command_registration adapter_usb_command_handlers[] = {
 #ifdef HAVE_LIBUSB_GET_PORT_NUMBERS
 	{
@@ -780,6 +845,13 @@ static const struct command_registration adapter_usb_command_handlers[] = {
 		.usage = "[<bus>-port[.port]...]",
 	},
 #endif /* HAVE_LIBUSB_GET_PORT_NUMBERS */
+	{
+		.name = "bus_address",
+		.handler = &handle_usb_bus_device_address_command,
+		.mode = COMMAND_CONFIG,
+		.help = "set the bus and device address of the USB device",
+		.usage = "[bus]-[device_address]",
+	},
 	COMMAND_REGISTRATION_DONE
 };
 

--- a/src/jtag/adapter.h
+++ b/src/jtag/adapter.h
@@ -55,6 +55,17 @@ int adapter_config_rclk(unsigned int fallback_speed_khz);
 /** Retrieves the clock speed of the adapter in kHz. */
 unsigned int adapter_get_speed_khz(void);
 
+/** Retrieves bus number of the device. Return -1 if not initialized
+ *  Bus number can be 0 on Windows.
+ */
+int adapter_usb_get_bus_number(void);
+
+/** Retrieves device address of the device. Return -1 if not initialized */
+int adapter_usb_get_device_address(void);
+
+/** @returns true if bus and device address has been initialized */
+bool is_adapter_bus_address_initialized(void);
+
 /** Retrieves the serial number set with command 'adapter serial' */
 const char *adapter_get_required_serial(void);
 

--- a/src/jtag/drivers/ftdi.c
+++ b/src/jtag/drivers/ftdi.c
@@ -748,7 +748,8 @@ static int ftdi_initialize(void)
 
 	for (int i = 0; ftdi_vid[i] || ftdi_pid[i]; i++) {
 		mpsse_ctx = mpsse_open(&ftdi_vid[i], &ftdi_pid[i], ftdi_device_desc,
-				adapter_get_required_serial(), adapter_usb_get_location(), ftdi_channel);
+				adapter_get_required_serial(), adapter_usb_get_location(), ftdi_channel,
+				adapter_usb_get_bus_number() , adapter_usb_get_device_address());
 		if (mpsse_ctx)
 			break;
 	}

--- a/src/jtag/drivers/mpsse.c
+++ b/src/jtag/drivers/mpsse.c
@@ -160,7 +160,7 @@ static bool device_location_equal(struct libusb_device *device, const char *loca
  * the already opened handle. ctx->interface must be set to the desired interface (channel) number
  * prior to calling this function. */
 static bool open_matching_device(struct mpsse_ctx *ctx, const uint16_t *vid, const uint16_t *pid,
-	const char *product, const char *serial, const char *location)
+	const char *product, const char *serial, const char *location, int bus_number, int device_address)
 {
 	struct libusb_device **list;
 	struct libusb_device_descriptor desc;
@@ -203,6 +203,16 @@ static bool open_matching_device(struct mpsse_ctx *ctx, const uint16_t *vid, con
 		}
 
 		if (serial && !string_descriptor_equal(ctx->usb_dev, desc.iSerialNumber, serial)) {
+			libusb_close(ctx->usb_dev);
+			continue;
+		}
+
+		if (bus_number >= 0 && bus_number != libusb_get_bus_number(device)) {
+			libusb_close(ctx->usb_dev);
+			continue;
+		}
+
+		if (device_address >= 0 && device_address != libusb_get_device_address(device)) {
 			libusb_close(ctx->usb_dev);
 			continue;
 		}
@@ -319,7 +329,7 @@ error:
 }
 
 struct mpsse_ctx *mpsse_open(const uint16_t *vid, const uint16_t *pid, const char *description,
-	const char *serial, const char *location, int channel)
+	const char *serial, const char *location, int channel, int bus_number, int device_address)
 {
 	struct mpsse_ctx *ctx = calloc(1, sizeof(*ctx));
 	int err;
@@ -354,17 +364,21 @@ struct mpsse_ctx *mpsse_open(const uint16_t *vid, const uint16_t *pid, const cha
 		goto error;
 	}
 
-	if (!open_matching_device(ctx, vid, pid, description, serial, location)) {
+	if (!open_matching_device(ctx, vid, pid, description, serial, location, bus_number, device_address)) {
 		/* Four hex digits plus terminating zero each */
 		char vidstr[5];
 		char pidstr[5];
+		char busstr[4];
+		char addressstr[4];
 		LOG_ERROR("unable to open ftdi device with vid %s, pid %s, description '%s', "
-				"serial '%s' at bus location '%s'",
+				"serial '%s' at bus location '%s' or bus:address %s:%s",
 				vid ? sprintf(vidstr, "%04x", *vid), vidstr : "*",
 				pid ? sprintf(pidstr, "%04x", *pid), pidstr : "*",
 				description ? description : "*",
 				serial ? serial : "*",
-				location ? location : "*");
+				location ? location : "*",
+				bus_number >= 0 ? sprintf(busstr, "%03u", (uint8_t)bus_number), busstr : "*",
+				device_address >= 0 ? sprintf(busstr, "%03u", (uint8_t)device_address), addressstr : "*");
 		ctx->usb_dev = 0;
 		goto error;
 	}

--- a/src/jtag/drivers/mpsse.h
+++ b/src/jtag/drivers/mpsse.h
@@ -41,7 +41,7 @@ struct mpsse_ctx;
 
 /* Device handling */
 struct mpsse_ctx *mpsse_open(const uint16_t *vid, const uint16_t *pid, const char *description,
-	const char *serial, const char *location, int channel);
+	const char *serial, const char *location, int channel, int bus_number, int device_address);
 void mpsse_close(struct mpsse_ctx *ctx);
 bool mpsse_is_high_speed(struct mpsse_ctx *ctx);
 


### PR DESCRIPTION
1. add the `bus_address` command to set bus number and address.
2. pass bus number and device address to ftdi driver.