### PR TITLE
riscv: cap progbuf data_bits to 32 to fix peripheral reads on RV64

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1868,7 +1868,7 @@ static unsigned riscv013_data_bits(struct target *target)
 
 		if (method == RISCV_MEM_ACCESS_PROGBUF) {
 			if (has_sufficient_progbuf(target, 3))
-				return riscv_xlen(target);
+				return 32;
 		} else if (method == RISCV_MEM_ACCESS_SYSBUS) {
 			if (get_field(info->sbcs, DM_SBCS_SBACCESS128))
 				return 128;


### PR DESCRIPTION
Change-Id: Ib1be83bfce7a572378930884000b86e6599b4af8